### PR TITLE
🐞: chat crash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,64 +1,50 @@
 source "https://rubygems.org"
 
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.2.1"
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
+# Backend gems
+gem "rails", "~> 7.2.1"                      # Core Rails framework
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.5"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
+# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
+gem "bcrypt", "~> 3.1.7"
+# API wrapper for Mailgun [https://github.com/mailgun/mailgun-ruby]
+gem "mailgun-ruby"
+# API wrapper for OpenAI [https://github.com/alexrudall/ruby-openai]
+gem "ruby-openai"
+# Load environment variables from .env files [https://github.com/bkeepers/dotenv]
+gem "dotenv-rails"
+# Authentication framework for Rails [https://github.com/heartcombo/devise]
+gem "devise"
+
+# Frontend gems
+# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
+gem "sprockets-rails"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder"
-# Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
-
-# Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", require: false
-
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
-
-# Load environment variables from .env files [https://github.com/bkeepers/dotenv]
-gem "dotenv-rails"
-
-# Authentication framework for Rails [https://github.com/heartcombo/devise]
-gem "devise"
-
-# Simple HTTP client for Ruby [https://github.com/httprb/http]
-gem "http"
-
-# API wrapper for Mailgun [https://github.com/mailgun/mailgun-ruby]
-gem "mailgun-ruby"
-
-# API wrapper for OpenAI [https://github.com/alexrudall/ruby-openai]
-gem "ruby-openai"
-
 # Styling framework for Rails with Tailwind CSS [https://github.com/rails/tailwindcss-rails]
 gem "tailwindcss-rails"
 
+# Utility gems
+# Build JSON APIs with ease [https://github.com/rails/jbuilder]
+gem "jbuilder"
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "tzinfo-data", platforms: %i[ windows jruby ]
+# Reduces boot times through caching; required in config/boot.rb
+gem "bootsnap", require: false
+# Redcarpet gem for Markdown parsing
+gem "redcarpet"
+
+# Development and testing
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
-
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
-
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Backend gems
-gem "rails", "~> 7.2.1"                      # Core Rails framework
+gem "rails", "~> 7.2.1"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.5"
 # Use the Puma web server [https://github.com/puma/puma]
@@ -43,8 +43,10 @@ gem "redcarpet"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
+
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 # Backend gems
+# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.26.3)
     parser (3.3.5.0)
@@ -303,6 +305,8 @@ GEM
     stringio (3.1.1)
     tailwindcss-rails (2.7.8-arm64-darwin)
       railties (>= 7.0.0)
+    tailwindcss-rails (2.7.8-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.3.2)
     timeout (0.4.1)
     turbo-rails (2.0.10)
@@ -331,6 +335,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,24 +122,11 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.3.0)
       net-http
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
-    ffi-compiler (1.3.2)
-      ffi (>= 1.15.5)
-      rake
     globalid (1.2.1)
       activesupport (>= 6.1)
-    http (5.2.0)
-      addressable (~> 2.8)
-      base64 (~> 0.1)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.5.0)
     http-accept (1.7.0)
     http-cookie (1.0.7)
       domain_name (~> 0.5)
-    http-form_data (2.3.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.2)
@@ -155,9 +142,6 @@ GEM
       activesupport (>= 5.0.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    llhttp-ffi (0.5.0)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -177,7 +161,7 @@ GEM
     mime-types-data (3.2024.1001)
     mini_mime (1.1.5)
     minitest (5.25.1)
-    msgpack (1.7.2)
+    msgpack (1.7.3)
     multipart-post (2.4.1)
     net-http (0.4.1)
       uri
@@ -192,11 +176,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.3)
-    nokogiri (1.16.7-aarch64-linux)
-      racc (~> 1.4)
     nokogiri (1.16.7-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.26.3)
@@ -251,6 +231,7 @@ GEM
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -262,7 +243,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -278,10 +259,10 @@ GEM
     rubocop-minitest (0.36.0)
       rubocop (>= 1.61, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-performance (1.21.1)
+    rubocop-performance (1.22.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rails (2.26.1)
+    rubocop-rails (2.26.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.52.0, < 2.0)
@@ -320,11 +301,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
-    tailwindcss-rails (2.7.7-aarch64-linux)
-      railties (>= 7.0.0)
-    tailwindcss-rails (2.7.7-arm64-darwin)
-      railties (>= 7.0.0)
-    tailwindcss-rails (2.7.7-x86_64-linux)
+    tailwindcss-rails (2.7.8-arm64-darwin)
       railties (>= 7.0.0)
     thor (1.3.2)
     timeout (0.4.1)
@@ -353,9 +330,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
-  aarch64-linux
   arm64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
@@ -365,13 +340,13 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
-  http
   importmap-rails
   jbuilder
   mailgun-ruby
   pg (~> 1.5)
   puma (>= 5.0)
   rails (~> 7.2.1)
+  redcarpet
   rubocop-rails-omakase
   ruby-openai
   selenium-webdriver
@@ -384,4 +359,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.4.6
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Ensure you have the following installed on your machine:
 - Rails 7.x.x
 - PostgreSQL (for database)
 
+.env
+```bash
+DATABASE_URL=..
+MAILGUN_KEY=..
+MAILGUN_DOMAIN=..
+OPENAI_KEY=..
+```
+
 ### Installation
 
 1. Clone the repository:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
   # Mailgun
   config.action_mailer.delivery_method = :mailgun
   config.action_mailer.mailgun_settings = {
-    api_key: ENV["MAILGUN_API_KEY"],
+    api_key: ENV["MAILGUN_KEY"],
     domain: ENV["MAILGUN_DOMAIN"]
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,7 +106,7 @@ Rails.application.configure do
   # Mailgun settings for production email delivery.
   config.action_mailer.delivery_method = :mailgun
   config.action_mailer.mailgun_settings = {
-    api_key: ENV["MAILGUN_API_KEY"],
+    api_key: ENV["MAILGUN_KEY"],
     domain: ENV["MAILGUN_DOMAIN"]
   }
 


### PR DESCRIPTION
#136

### Description
- `redcarpet` was removed in 6867b71adcdf064d62e2984664ba470a1e2e236c, as `posts` controller was removed a384e9fedb41be2dff9b06968844c0f5ca0df2c1
- this caused `chats` bug as dep unavail

### Misc.
- grouped 💎  (`Gemfile`)

### Todo
- [x] check deployed env variable naming matches code change before merging
  - [x] not in yet #46

### Later
#141